### PR TITLE
Add train_list variable, remove weekend_notify, clean up comments.

### DIFF
--- a/metrolink_advisories.py
+++ b/metrolink_advisories.py
@@ -15,21 +15,19 @@ Then, modify the below variables.
       - https://support.google.com/accounts/answer/185833
       - Should be 16 characters, don't enter spaces.
   - TO_EMAIL       - email address that will recieve the email.
-      - It is reccomended to use a different email address to ensure you get the notification.
+      - It is recomended to use a different email address to ensure you get the notification.
   - FILENAME       - name of the temporary file to generate. Don't need to change this normally.
   - WINDOWS        - set to "False" if on a linux machine or docker container.
-  - WEEKEND_NOTIFY - set to "True" if you want to be notified of train delays on weekends.
+  - TRAIN_LIST     - set to a list of your trains. e.g. ["201", "103", "602"]
 
-Next, put your train numbers in retrieve_advisories() method where it says "//Modify array with your train numbers".
+If you want the script to run continuously (as a startup application for example), go to the bottom.
+ Uncomment "runon_schedule(300.00, TRAIN_LIST)".
+    - You can change the number of seconds (e.g. 500.00 opposed to 300.00)
+    - Comment the main("", "",  TRAIN_LIST)
 
-Finally, go to the very bottom.
-  - Uncomment "main("","")" if you want this script to run once.
-  - or uncomment "runon_schedule(300.00)" to keep this script running, and check every 300 seconds.
-    - You can also change the number of seconds (e.g. 500.0)
-    - Do not do this if you are using GCP cloud functions or AWS Lambda functions to run this.
-    - Add this python script to your startup.
-
-Remember to add execution permissions to this script on linux.
+Reminders:
+  - Add execution permissions to this script on linux.
+  - Just run the script normally on GCP Cloud Functions or Lambda, don't make it run continuously.
 """
 
 SENDER_EMAIL   = ""
@@ -37,7 +35,7 @@ GOOGLE_APP_KEY = ""
 TO_EMAIL       = ""
 FILENAME       = "sent_advisories.txt"
 WINDOWS        = True
-WEEKEND_NOTIFY = False
+TRAIN_LIST     = []
 
 class ServiceAdvisory:
     """Class used for any service advisories.
@@ -46,7 +44,7 @@ class ServiceAdvisory:
     metro_response / response   - string, this is the raw response, passed when creating the class.
     advisory_time               - string, time the advisory was put onto the website.
     advisory_message            - string, the actual advisory message i.e. "AV Line 225 to Lancaster will use track 4B at LA Union Station".
-    line                        - string, line and train number the advisory is occuring for. i.e. "AV Line 225"
+    line                        - string, line and train number the advisory is occuring for i.e. "AV Line 225"
     """
     def __init__(self, metro_response):
         self.response = metro_response
@@ -54,7 +52,7 @@ class ServiceAdvisory:
         self.advisory_message = self.response.split("<p>")[2].replace("</p>", "").strip()
         self.line = self.advisory_message.split("to")[0]
 
-def retrieve_advisories():
+def retrieve_advisories(trainList):
     """Retrieves advisories from the metrolinktrains.com website.
 
     Using requests_html library to get a session from the website.
@@ -73,9 +71,7 @@ def retrieve_advisories():
             var array = Array.from(document.getElementsByClassName("accordionAdvisories__service-advisory"))
             var array2 = []
             var rtn_array = []
-
-            // Modify array with your train numbers:
-            var train_array = ["123", "456", "789"]
+            var train_array = """ + str(trainList) + """
 
             Array.prototype.forEach.call(array, function(el) {
                 array2.push(el.children.item(1).innerHTML);
@@ -166,9 +162,8 @@ def been_notified(filename, advisory):
     advisory_file.close()
     return False
 
-def handle_advisories(response_list, reciever_email, sender_email, filename, password, weekend_notify, windows):
+def handle_advisories(response_list, reciever_email, sender_email, filename, password, windows):
     """ Handles advisories, acts as a main method.
-    Will not notify a user about advisories on weekends by default.
 
     Arguments:
     response_list   - list, list of responses (advisories) from the metro website
@@ -176,7 +171,7 @@ def handle_advisories(response_list, reciever_email, sender_email, filename, pas
     sender_email    - string, email address that sends the email
     filename        - string, name of the previous advisories file
     password        - string, Google App Key with Mail permissions.
-    weekend_notify  - boolean, true to notify on weekends.
+    windows         - boolean, set to True if on Windows, false otherwise.
     """
     # Adding linux compatability for the datetime string.
     if(windows):
@@ -186,33 +181,31 @@ def handle_advisories(response_list, reciever_email, sender_email, filename, pas
 
     # Looping through each advisory for your trains.
     for metro_response in response_list:
-        # If it isn't a weekend, and the advisory occured today:
-        if(datetime.datetime.today().weekday() < 5 or weekend_notify):
-            if(today in metro_response):
-                # If you haven't been notified already, then notify you
-                # and add the response to the advisory file.
-                if(not been_notified(filename, ServiceAdvisory(metro_response))):
-                    send_mail(ServiceAdvisory(metro_response), reciever_email, sender_email, password)
-                    update_advisory_file(filename, ServiceAdvisory(metro_response))
+        if(today in metro_response):
+            # If you haven't been notified already, then notify you
+            # and add the response to the advisory file.
+            if(not been_notified(filename, ServiceAdvisory(metro_response))):
+                send_mail(ServiceAdvisory(metro_response), reciever_email, sender_email, password)
+                update_advisory_file(filename, ServiceAdvisory(metro_response))
     print("Finished.")
 
 # Arguments and method included if you want to attempt to get this working with AWS Lambda.
-def main(context, response):
+def main(context, response, trainList):
     print("Starting execution.")
-    response_list = retrieve_advisories()
-    handle_advisories(response_list, TO_EMAIL, SENDER_EMAIL, FILENAME, GOOGLE_APP_KEY, WEEKEND_NOTIFY, WINDOWS)
+    response_list = retrieve_advisories(trainList)
+    handle_advisories(response_list, TO_EMAIL, SENDER_EMAIL, FILENAME, GOOGLE_APP_KEY, WINDOWS)
 
 # Running continuously to avoid cron (for docker and linux).
-def runon_schedule(delay_seconds):
+def runon_schedule(delay_seconds, trainList):
     starttime = time.time()
     while True:
-        main("","")
+        main("","", trainList)
         print("Waiting " +str(delay_seconds)+ " seconds.")
         time.sleep(delay_seconds - ((time.time() - starttime) % delay_seconds))
         print("Running again.\n")
 
 # To just run once:
-# main("", "")
+main("", "", TRAIN_LIST)
 
 # To run on schedule:
-# runon_schedule(300.00)
+# runon_schedule(300.00, TRAIN_LIST)


### PR DESCRIPTION
- Fixes spelling mistake in comments.
- Removes weekend_notify variable (weekend trains have unique numbers compared to weekday trains).
- Adds TRAIN_LIST global variable, a list of trains you want to monitor.
- Cleans up comments at beginning of the script.
- Removes the need to edit the script string in retrieve_advisories method.
- Uncomments "main" call at the end by default. 